### PR TITLE
Point to `backend_py` for LangGraph Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ DB_ENDPOINT_URL=http://host.docker.internal:3001" > backend_py/.env
 
 2. **Start Studio** 
 
-If using python locally, for example, open the `backend_py/my_agent` as a project in the LangGraph Studio desktop applications. Studio gives us direct access to the LangGraph API via a URL that is visible in the lower left corner of the Studio UI. Note that we can also use [LangGraph Cloud](https://langchain-ai.github.io/langgraph/cloud/) to deploy and host our back-end.
+If using python locally, for example, open the `backend_py` as a project in the LangGraph Studio desktop applications. Studio gives us direct access to the LangGraph API via a URL that is visible in the lower left corner of the Studio UI. Note that we can also use [LangGraph Cloud](https://langchain-ai.github.io/langgraph/cloud/) to deploy and host our back-end.
 
 #### Frontend
 


### PR DESCRIPTION
removed the 'my_agent' path of the project selected to start LangGraph Studio. The origin settings would fail, as LangGraph studio would look for `my_agent/my_agent/main.py` Simply select 'backend_py' would do the magic